### PR TITLE
docs: clean up shell script for copy pasta

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,8 @@ overwhelming security engineers and CISOs with too much data.
 
 In general you will want to use the OCI image:
 
-```
-% docker run --rm -it ghcr.io/edera-dev/am-i-isolated:nightly
-...
+```sh
+docker run --rm -it ghcr.io/edera-dev/am-i-isolated:nightly
 ```
 
 However, you can also build and run directly with Cargo.


### PR DESCRIPTION
README formats the shell script for docker command to copy/paste, but it includes shell formatting.

PR removes formatting to make it easier to get started.