### PR TITLE
fix(virtualized): detect gVisor more reliably, and introduce a maybe present state

### DIFF
--- a/src/cap.rs
+++ b/src/cap.rs
@@ -41,8 +41,10 @@ impl Test for CapTest {
         let mut result = CapResult { flags: 0 };
 
         if let Ok(stat) = read_file_as_tuples("/proc/self/status") {
-            if let Ok(flags) = u64::from_str_radix(stat["CapAmb"].as_str(), 16) {
-                result.flags |= flags;
+            if stat.contains_key("CapAmb") {
+                if let Ok(flags) = u64::from_str_radix(stat["CapAmb"].as_str(), 16) {
+                    result.flags |= flags;
+                }
             }
 
             if let Ok(flags) = u64::from_str_radix(stat["CapEff"].as_str(), 16) {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,7 @@
-use std::collections::HashMap;
 use std::fs::read_to_string;
 use std::path::Path;
 use std::ptr::addr_of_mut;
+use std::{collections::HashMap, fs};
 
 use libc::uname;
 
@@ -67,4 +67,22 @@ pub fn kernel_release_info() -> (String, (u32, u32, u32)) {
         .collect();
 
     (release, (parts[0], parts[1], parts[2]))
+}
+
+pub fn kernel_cmdline() -> Vec<String> {
+    fs::read_to_string("/proc/cmdline")
+        .ok()
+        .unwrap_or_default()
+        .split(" ")
+        .map(|part| part.to_string())
+        .collect()
+}
+
+pub fn is_running_gvisor() -> bool {
+    let cmdline = kernel_cmdline();
+    if let Some(first) = cmdline.first() {
+        first.starts_with("BOOT_IMAGE=/vmlinuz-") && first.ends_with("-gvisor")
+    } else {
+        false
+    }
 }


### PR DESCRIPTION
Inherently, detecting running under virtualization is hard on some virtualization runtimes. This change attempts to improve that situation by detecting container runtime env vars, and detecting gVisor using /proc/cmdline. Kata Containers cannot be reliably determined using this version of Am I Isolated, but the fallback uptime check test might present a maybe present result, to indicate that signs were detected.