### PR TITLE
fix(dirtypipe): fix kernel version parsing with non-numeric portions

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -62,7 +62,7 @@ pub fn kernel_release_info() -> (String, (u32, u32, u32)) {
     };
 
     let parts: Vec<u32> = release
-        .splitn(3, ".")
+        .split(".")
         .map(|x| x.trim().parse::<u32>().ok().unwrap_or(0))
         .collect();
 


### PR DESCRIPTION
5.15.167.4-microsoft-standard-WSL2 was parsing as [5, 15, 0].

Fixes: https://github.com/edera-dev/am-i-isolated/issues/48