### PR TITLE
docs: fix YAML syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ docker run --rm -it ghcr.io/edera-dev/am-i-isolated:nightly
 
 To detect isolation gaps in your Kubernetes environments, you can run it as a Pod
 
-```sh
+```yaml
 apiVersion: v1
 kind: Pod
 metadata:


### PR DESCRIPTION
## Summary

Fix syntax highlighting for the YAML code block in the README

## Details

- the syntax for the block was `sh`, but this block is YAML (k8s Pod manifest) unlike the other shell blocks

## Verification

See proper syntax highlighting in [the rendered commit of this PR](https://github.com/edera-dev/am-i-isolated/blob/4ccd3fd94d187d72deb0989bd69de4ce15c6c13a/README.md#using-am-i-isolated)