### PR TITLE
rust: pin to v1.85.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "am-i-isolated"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -18,6 +18,6 @@ checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "am-i-isolated"
-version = "0.3.0"
-edition = "2021"
+version = "0.4.0"
+edition = "2024"
+rust-version = "1.85.0"
 
 [dependencies]
 anyhow = "1.0.97"
-libc = "0.2.170"
+libc = "0.2.171"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/rust:1.84-alpine@sha256:fdff417c3845c92360b439382f7d6dabca6c998f59c8dce6cd2a16a2e9e85498 AS build
+FROM docker.io/library/rust:1.85-alpine@sha256:bea885d2711087e67a9f7a7cd1a164976f4c35389478512af170730014d2452a AS build
 
 WORKDIR /usr/src/app
 COPY . .

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.85.0"


### PR DESCRIPTION
This pins am-i-isolated to Rust v1.85.0 and also upgrades libc to the latest version.